### PR TITLE
Fix weird spacing in timeline descriptions

### DIFF
--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -69,9 +69,9 @@ const TimelineSection = () => {
                     <h3 className="text-xl font-bold text-lg-blue-dark font-display tracking-tight">{step.title}</h3>
                   </div>
                   
-                  {/* Card body with proper text justification */}
+                  {/* Card body with clean text formatting */}
                   <div className="px-6 flex-grow flex flex-col">
-                    <p className="text-base text-lg-gray leading-relaxed mb-4 text-justify">{step.description}</p>
+                    <p className="text-base text-lg-gray leading-relaxed mb-4">{step.description}</p>
                     
                     {/* Bullet points with vertical alignment */}
                     <div className="mb-auto">
@@ -115,9 +115,9 @@ const TimelineSection = () => {
                     <h3 className="text-xl font-bold text-lg-blue-dark font-display tracking-tight">{step.title}</h3>
                   </div>
                   
-                  {/* Card body with proper text justification */}
+                  {/* Card body with clean text formatting */}
                   <div className="px-6 flex-grow flex flex-col">
-                    <p className="text-base text-lg-gray leading-relaxed mb-4 text-justify">{step.description}</p>
+                    <p className="text-base text-lg-gray leading-relaxed mb-4">{step.description}</p>
                     
                     {/* Bullet points with vertical alignment */}
                     <div className="mb-auto">


### PR DESCRIPTION
## Summary
- Removed text-justify class from timeline descriptions that was causing awkward word spacing
- Updated comment to reflect the change
- Text now flows naturally with normal spacing between words

## Test plan
- Verify timeline descriptions have natural, readable text flow
- Confirm text is properly aligned and formatted

🤖 Generated with [Claude Code](https://claude.ai/code)